### PR TITLE
Elements (labels or lines) may not be displayed

### DIFF
--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -735,8 +735,7 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
         } else {
         // update a label
             featureLabel = layer.features[labelsNumber - 1];
-            featureLabel.geometry.x = xy[0];
-            featureLabel.geometry.y = xy[1];
+            featureLabel.geometry = new OpenLayers.Geometry.Point(xy[0], xy[1]);
             this.setMesureAttributes(featureLabel.attributes, measure);
             layer.drawFeature(featureLabel);
             if (maxSegments !== null) {

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -652,11 +652,16 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
      * Returns:
      * {Boolean}
      */
-    showLabelSegment: function(labelsNumber, fromIndex, points) {
+    showLabelSegment: function(labelsNumber, fromIndex, _points) {
         var layerSegments = this.layerSegments,
             layerHeading = this.layerHeading;
         if (!layerSegments && !layerHeading) {
             return false;
+        }
+        // clone points
+        var points = [];
+        for (var i = 0; i < _points.length; i++) {
+            points.push(_points[i].clone());
         }
         var from = points[0],
             to = points[points.length - 1],


### PR DESCRIPTION
When the map is panned, in some cases, lines or labels disapear while drawing.
Way to reproduce:
- load [measure dynamic example](http://jorix.github.io/OL-DynamicMeasure/examples/measure-dynamic.html),
- activate the measure length control,
- click on the map to add the first point,
- click-drag the map to pan so that the first point gets out of visible area,
- move the mouse cursor -> the line and the labels disapear.
