### PR TITLE
Remove the BOM and use unix line-endings

### DIFF
--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -1,4 +1,4 @@
-﻿/* Copyright 2011-2014 Xavier Mamano, http://github.com/jorix/OL-DynamicMeasure
+/* Copyright 2011-2014 Xavier Mamano, http://github.com/jorix/OL-DynamicMeasure
  * Published under MIT license. */
 
 /**


### PR DESCRIPTION
This PR suggests that the source code uses unix lineendings and also removes the byte order mark at the beginning.
