### PR TITLE
Persistent annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ See the example [measure-dynamic-dev.html](http://jorix.github.com/OL-DynamicMea
 
 The control can use it as a `DrawFeature` control, see example [measure-and-draw.html](http://jorix.github.com/OL-DynamicMeasure/examples/measure-and-draw.html)
 
+Measure annotations are shown for the current measurement by default. They can be keeped for all measures using the `keep` property, see example [measure-and-keep.html](http://jorix.github.com/OL-DynamicMeasure/examples/measure-and-keep.html)
+
 Documentation:
 --------------
  * [API for users](http://jorix.github.com/OL-DynamicMeasure/doc/DynamicMeasure/api)

--- a/doc/_scripts/documentation.sh
+++ b/doc/_scripts/documentation.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+naturaldocs -i ../../lib/OpenLayers/Control -hl All -s Default ../../../_scripts/jorix -o HTML ../DynamicMeasure/all -p ../DynamicMeasure/all/_config
+naturaldocs -i ../../lib/OpenLayers/Control -hl All -s Default ../../../_scripts/jorix -o HTML ../DynamicMeasure/api -p ../DynamicMeasure/api/_config

--- a/examples/measure-and-keep.html
+++ b/examples/measure-and-keep.html
@@ -8,6 +8,7 @@
     for measure and draw vector features with label persistance.">
     <meta name="keywords" content="OpenLayers, vertices, draw, drawing, modify, 
     delete">
+    <link rel="stylesheet" href="http://jorix.github.com/OL-Ragbag/examples/github-pages/forkme_banner.css" type="text/css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
@@ -28,6 +29,7 @@
   <body>
     <h1 id="title">Example of OpenLayers to measure and draw features with
     persitent labels</h1>
+    <a id="forkme_banner" href="https://github.com/jorix/OL-Ragbag/blob/gh-pages/README.md">View on GitHub</a>
     <div id="tags">vertices, draw, measure, drawing, modify, delete</div>
     <div id="shortdesc">Example of DynamicMeasure control for measure and draw vector features.</div>
     <div id="map" class="smallmap"></div>
@@ -47,6 +49,12 @@
             </li>
         </ul>
     </div>
+    <div id="emptyKeepedNote"><p>When DynamicMeasure is created with <code>keep=true</code>.
+    We have to call the emptyKeeped method on the control to remove annotations.</p></div>
+    <div>
+        <p><button onclick="emptyAllKeeped()">Empty keeped annotations!</button></p>
+    </div>
+    
     <div id="docs">
         <p>
             View the <a href="measure-and-keep.js" target="_blank">measure-and-keep.js</a> 

--- a/examples/measure-and-keep.html
+++ b/examples/measure-and-keep.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="lang" content="en">
+    <meta name="author" content="Jean-Denis Giguère" >
+    <meta name="description" content="Usage example of f DynamicMeasure control 
+    for measure and draw vector features with label persistance.">
+    <meta name="keywords" content="OpenLayers, vertices, draw, drawing, modify, 
+    delete">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <title>Example of OpenLayers to measure and draw features with persistent labels (keep)</title>
+
+    <link rel="stylesheet" href="http://dev.openlayers.org/theme/default/style.css" type="text/css">
+    <link rel="stylesheet" href="http://dev.openlayers.org/examples/style.css" type="text/css">
+    <style type="text/css">
+        #controlToggle {padding-left: 1em;}
+        #controlToggle li {list-style: none;}
+    </style>
+
+    <script src="http://dev.openlayers.org/OpenLayers.js"></script>
+    <script src="../lib/OpenLayers/Control/DynamicMeasure.js"></script>
+
+
+  </head>
+  <body>
+    <h1 id="title">Example of OpenLayers to measure and draw features with
+    persitent labels</h1>
+    <div id="tags">vertices, draw, measure, drawing, modify, delete</div>
+    <div id="shortdesc">Example of DynamicMeasure control for measure and draw vector features.</div>
+    <div id="map" class="smallmap"></div>
+    <div id="controls">
+        <ul id="controlToggle">
+            <li>
+                <input type="radio" name="type" value="none" id="noneToggle" onclick="toggleControl(this);" checked="checked" />
+                <label for="noneToggle">none</label>
+            </li>
+            <li>
+                <input type="radio" name="type" value="line" id="lineToggle" onclick="toggleControl(this);" />
+                <label for="lineToggle">draw line</label>
+            </li>
+            <li>
+                <input type="radio" name="type" value="polygon" id="polygonToggle" onclick="toggleControl(this);" />
+                <label for="polygonToggle">draw polygon</label>
+            </li>
+        </ul>
+    </div>
+    <div id="docs">
+        <p>
+            View the <a href="measure-and-keep.js" target="_blank">measure-and-keep.js</a> 
+            source to see how this is done.
+        </p>
+    </div>
+    <script src="measure-and-keep.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/examples/measure-and-keep.js
+++ b/examples/measure-and-keep.js
@@ -153,7 +153,9 @@ function toggleControl(element) {
 }
 
 function emptyAllKeeped() {
+    controls.line.deactivate();
     controls.line.emptyKeeped();
+    controls.polygon.deactivate();
     controls.polygon.emptyKeeped();
 }
 

--- a/examples/measure-and-keep.js
+++ b/examples/measure-and-keep.js
@@ -1,0 +1,154 @@
+// Alter default OpenLayers options
+// --------------------------------
+
+// Allow testing of specific renderers via "?renderer=Canvas", etc
+var renderer = OpenLayers.Util.getParameters(window.location.href).renderer;
+OpenLayers.Layer.Vector.prototype.renderers = renderer ?
+                                    [renderer] :
+                                    OpenLayers.Layer.Vector.prototype.renderers;
+
+OpenLayers.Feature.Vector.style['default']['strokeWidth'] = '3';
+
+// Create Objects
+// --------------
+
+// To report draw modify and delete events
+var reportEvent;
+if (window.console && window.console.log) {
+    reportEvent = function(event) {
+        console.log(event.type,
+                    event.feature ? event.feature.id : event.components);
+    };
+} else {
+    reportEvent = function() {};
+}
+
+// Create the vectorial layer
+var vectorLayer = new OpenLayers.Layer.Vector('Vector Layer');
+vectorLayer.events.on({
+    'beforefeaturemodified': reportEvent,
+    'featuremodified': function(e) {
+        e.feature.state = OpenLayers.State.UPDATE;
+        reportEvent(e);
+    },
+    'afterfeaturemodified': reportEvent,
+    'beforefeatureremoved': reportEvent,
+    'featureremoved': reportEvent,
+    'vertexmodified': reportEvent,
+    'sketchmodified': reportEvent,
+    'sketchstarted': reportEvent,
+    'sketchcomplete': reportEvent
+});
+
+// Create and show the map
+var map = new OpenLayers.Map({
+    div: 'map',
+    layers: [
+        new OpenLayers.Layer.WMS('osgeo WMS',
+                  'http://vmap0.tiles.osgeo.org/wms/vmap0?', {layers: 'basic'}),
+        vectorLayer,
+    ]
+});
+map.setCenter(new OpenLayers.LonLat(0, 0), 3);
+
+var styleLine = {
+    'Point': {
+        pointRadius: 4,
+        graphicName: 'square',
+        fillColor: 'white',
+        fillOpacity: 1,
+        strokeWidth: 1,
+        strokeOpacity: 1,
+        strokeColor: '#333333'
+    },
+    'Line': {
+        strokeWidth: 2,
+        strokeOpacity: 1,
+        strokeColor: '#666666',
+        strokeDashstyle: 'dash'
+    },
+    'Polygon': {
+        strokeWidth: 2,
+        strokeOpacity: 1,
+        strokeColor: '#666666',
+        strokeDashstyle: 'solid',
+        fillColor: 'white',
+        fillOpacity: 0.3
+    },
+    labelSegments: {
+        label: '${measure} ${units}',
+        fontSize: '11px',
+        fontColor: '#7661AB',
+        fontFamily: 'Verdana',
+        labelOutlineColor: '#dddddd',
+        labelAlign: 'cm',
+        labelOutlineWidth: 2
+    },
+    labelLength: {
+        label: '${measure} ${units}\n',
+        fontSize: '11px',
+        fontWeight: 'bold',
+        fontColor: '#800517',
+        fontFamily: 'Verdana',
+        labelOutlineColor: '#dddddd',
+        labelAlign: 'lb',
+        labelOutlineWidth: 3
+    },
+    labelArea: {
+        label: '${measure}\n${units}²\n',
+        fontSize: '11px',
+        fontWeight: 'bold',
+        fontColor: '#800517',
+        fontFamily: 'Verdana',
+        labelOutlineColor: '#dddddd',
+        labelAlign: 'cm',
+        labelOutlineWidth: 3
+    },
+    labelHeading: {
+        label: '${measure} ${units}',
+        fontSize: '11px',
+        fontColor: '#800517',
+        fontFamily: 'Verdana',
+        labelOutlineColor: '#dddddd',
+        labelAlign: 'cm',
+        labelOutlineWidth: 3
+    }
+};
+
+// Create the control collection to draw vectorial features.
+var controls = {
+    line: new OpenLayers.Control.DynamicMeasure(OpenLayers.Handler.Path, {
+        persist: true,
+        maxSegments: null,
+        drawingLayer: vectorLayer,
+        geodesic: true, // required by projection "EPSG:4326"
+        keep: true
+    }),
+    polygon: new OpenLayers.Control.DynamicMeasure(OpenLayers.Handler.Polygon, {
+        persist: false,
+        maxSegments: null,
+        drawingLayer: vectorLayer,
+        geodesic: true, // required by projection "EPSG:4326"
+        keep: true
+    })
+};
+// add this controls to the map
+for (var key in controls) {
+    map.addControl(controls[key]);
+}
+
+// Functions called from the form fields to choose the desired control to test.
+// ----------------------------------------------------------------------------
+
+// Function to toggle the active control
+function toggleControl(element) {
+    for (key in controls) {
+        var control = controls[key];
+        if (element.value === key && element.checked) {
+            control.activate();
+        } else {
+            control.deactivate();
+        }
+    }
+}
+

--- a/examples/measure-and-keep.js
+++ b/examples/measure-and-keep.js
@@ -153,9 +153,17 @@ function toggleControl(element) {
 }
 
 function emptyAllKeeped() {
+    var lineActive = controls.line.active,
+        polygonActive = controls.polygon.active;
     controls.line.deactivate();
     controls.line.emptyKeeped();
     controls.polygon.deactivate();
     controls.polygon.emptyKeeped();
+    if (lineActive) {
+        controls.line.activate();
+    }
+    if (polygonActive) {
+        controls.polygon.activate();
+    }
 }
 

--- a/examples/measure-and-keep.js
+++ b/examples/measure-and-keep.js
@@ -152,3 +152,8 @@ function toggleControl(element) {
     }
 }
 
+function emptyAllKeeped() {
+    controls.line.emptyKeeped();
+    controls.polygon.emptyKeeped();
+}
+

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -383,6 +383,7 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
      */
     destroy: function() {
         this.deactivate();
+        this.emptyKeeped();
         OpenLayers.Control.Measure.prototype.destroy.apply(this, arguments);
     },
 

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -440,16 +440,20 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
                 this.layerArea = _create('labelArea', this.layerAreaOptions);
             }
             if (this.keep) {
-                this.layerSegmentsKeep =
-                            _create('labelSegments', this.layerSegmentsOptions,
-                            'Keep');
-                this.layerLengthKeep =
-                            _create('labelLength', this.layerLengthOptions,
-                            'Keep');
-                if (this.isArea) {
+                if (!this.layerSegmentsKeep) {
+                    this.layerSegmentsKeep =
+                        _create('labelSegments', this.layerSegmentsOptions,
+                        'Keep');
+                }
+                if (!this.layerLengthKeep) {
+                    this.layerLengthKeep =
+                        _create('labelLength', this.layerLengthOptions,
+                        'Keep');
+                }
+                if (!this.layerAreaKeep) {
                     this.layerAreaKeep =
-                                _create('labelArea', this.layerAreaOptions,
-                                'Keep');
+                        _create('labelArea', this.layerAreaOptions,
+                        'Keep');
                 }
             }
         }
@@ -491,13 +495,13 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
      */
      emptyKeeped: function () {
         if (this.layerSegmentsKeep) {
-            this.layerSegmentsKeep.removeAllFeatures();
+            this.layerSegmentsKeep.destroyFeatures();
         }
         if (this.layerLengthKeep) {
-            this.layerLengthKeep.removeAllFeatures();
+            this.layerLengthKeep.destroyFeatures();
         }
         if (this.layerAreaKeep) {
-            this.layerAreaKeep.removeAllFeatures();
+            this.layerAreaKeep.destroyFeatures();
         }
     },
 

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -132,6 +132,12 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
     multi: false,
 
     /**
+     * APIProperty: keep
+     * {Boolean} Keep annotations for every measures.
+     */
+    keep: false,
+
+    /**
      * Property: layerSegments
      * {<OpenLayers.Layer.Vector>} The temporary drawing layer to show the
      *     length of the segments.
@@ -152,6 +158,26 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
      */
     layerArea: null,
 
+    /**
+     * Property: layerSegmentsKeep
+     * {<OpenLayers.Layer.Vector>} The layer keep a copy of the length of
+     *     every segments measured since tool activation.
+     */
+    layerSegmentsKeep: null,
+
+    /**
+     * Property: layersLengthKeep
+     * {<OpenLayers.Layer.Vector>} The layer keep a copy of the length of
+     *     every polyline/poly measured since tool activation.
+     */
+    layerLengthKeep: null,
+
+    /**
+     * Property: layerAreaKeep
+     * {<OpenLayers.Layer.Vector>} The layer keep a copy of the area of every
+     *     polygon
+     */
+    layerAreaKeep: null,
     /**
      * Property: dynamicObj
      * {Object} Internal use.
@@ -201,6 +227,10 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
      *     store the drawing when finished.
      * multi - {Boolean} Cast features to multi-part geometries before passing
      *     to the drawing layer
+     * keep - {Boolean} Keep annotations for every measures.
+     * PARTIAL IMPLEMENTATION.
+     * cumulative - {Boolean} Cumulative measurements. The length and area are
+       the sum of every measures since activation. NOT IMPLEMENTED YET.
      */
     initialize: function(handler, options) {
 
@@ -277,6 +307,9 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
                     );
                 },
                 done: function(geometry) {
+                    if (this.keep) {
+                        this.copyAnnotations();
+                    }
                     this.callbackDone(geometry);
                     this.drawFeature(geometry);
                 }
@@ -376,7 +409,7 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
             var _optionsStyles = this.styles || {},
                 _defaultStyles = OpenLayers.Control.DynamicMeasure.styles,
                 _self = this;
-            var _create = function(styleName, initialOptions) {
+            var _create = function(styleName, initialOptions, nameSuffix='') {
                 if (initialOptions === null) {
                     return null;
                 }
@@ -394,7 +427,8 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
                     });
                 }
                 var layer = new OpenLayers.Layer.Vector(
-                                   _self.CLASS_NAME + ' ' + styleName, options);
+                    _self.CLASS_NAME + ' ' + styleName + nameSuffix,
+                    options);
                 _self.map.addLayer(layer);
                 return layer;
             };
@@ -405,6 +439,19 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
             this.layerLength = _create('labelLength', this.layerLengthOptions);
             if (this.isArea) {
                 this.layerArea = _create('labelArea', this.layerAreaOptions);
+            }
+            if (this.keep) {
+                this.layerSegmentsKeep =
+                            _create('labelSegments', this.layerSegmentsOptions,
+                            'Keep');
+                this.layerLengthKeep =
+                            _create('labelLength', this.layerLengthOptions,
+                            'Keep');
+                if (this.isArea) {
+                    this.layerAreaKeep =
+                                _create('labelArea', this.layerAreaOptions,
+                                'Keep');
+                }
             }
         }
         return response;
@@ -495,6 +542,32 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
                 this.featureAdded(feature);
             }
             this.events.triggerEvent('featureadded', {feature: feature});
+        }
+    },
+
+    /**
+     * Method: copyAnnotations
+     */
+    copyAnnotations: function() {
+        var _insertable = function(feat) {
+            feat.state = OpenLayers.State.INSERT;
+        };
+        // Segments measures
+        var segments = this.layerSegments.clone();
+        var segmentsFeatures = segments.features;
+        segmentsFeatures.forEach(_insertable);
+        this.layerSegmentsKeep.addFeatures(segmentsFeatures);
+        // Length measures
+        var lengths = this.layerLength.clone();
+        var lengthsFeatures = lengths.features;
+        lengthsFeatures.forEach(_insertable);
+        this.layerLengthKeep.addFeatures(lengthsFeatures);
+        // Area measures
+        if (this.isArea) {
+            var areas = this.layerArea.clone();
+            var areasFeatures = areas.features;
+            areasFeatures.forEach(_insertable);
+            this.layerAreaKeep.addFeatures(areasFeatures);
         }
     },
 

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -228,9 +228,6 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
      * multi - {Boolean} Cast features to multi-part geometries before passing
      *     to the drawing layer
      * keep - {Boolean} Keep annotations for every measures.
-     * PARTIAL IMPLEMENTATION.
-     * cumulative - {Boolean} Cumulative measurements. The length and area are
-       the sum of every measures since activation. NOT IMPLEMENTED YET.
      */
     initialize: function(handler, options) {
 
@@ -483,6 +480,23 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
             this.layerArea = null;
         }
         return response;
+    },
+
+    /**
+     * APIMethod: emptyKeeped
+     * Remove annotation from layers layerSegementsKeep, layerLengthKeep,
+     * layerAreaKeep
+     */
+     emptyKeeped: function () {
+        if (this.layerSegmentsKeep) {
+            this.layerSegmentsKeep.removeAllFeatures();
+        }
+        if (this.layerLengthKeep) {
+            this.layerLengthKeep.removeAllFeatures();
+        }
+        if (this.layerAreaKeep) {
+            this.layerAreaKeep.removeAllFeatures();
+        }
     },
 
     /**

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -569,18 +569,24 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
         // Segments measures
         var segments = this.layerSegments.clone();
         var segmentsFeatures = segments.features;
-        segmentsFeatures.forEach(_insertable);
+        for(i = 0; i > segmentsFeatures.length; i++) {
+            segmentsFeatures[i].state = OpenLayers.State.INSERT;
+        }
         this.layerSegmentsKeep.addFeatures(segmentsFeatures);
         // Length measures
         var lengths = this.layerLength.clone();
         var lengthsFeatures = lengths.features;
-        lengthsFeatures.forEach(_insertable);
+        for(i = 0; i > lengthsFeatures.length; i++) {
+            lengthsFeatures[i].state = OpenLayers.State.INSERT;
+        }
         this.layerLengthKeep.addFeatures(lengthsFeatures);
         // Area measures
         if (this.isArea) {
             var areas = this.layerArea.clone();
             var areasFeatures = areas.features;
-            areasFeatures.forEach(_insertable);
+            for(i = 0; i > areasFeatures.length; i++) {
+                areasFeatures[i].state = OpenLayers.State.INSERT;
+            }
             this.layerAreaKeep.addFeatures(areasFeatures);
         }
     },

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -485,8 +485,8 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
 
     /**
      * APIMethod: emptyKeeped
-     * Remove annotation from layers layerSegementsKeep, layerLengthKeep,
-     * layerAreaKeep
+     * Remove annotations from layers layerSegementsKeep, layerLengthKeep,
+     * layerAreaKeep.
      */
      emptyKeeped: function () {
         if (this.layerSegmentsKeep) {

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -384,6 +384,19 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
     destroy: function() {
         this.deactivate();
         this.emptyKeeped();
+            //keep status may have change, destroy layerXxxxxKeep anyway
+            if (this.layerSegmentsKeep) {
+	             this.layerSegmentsKeep.destroyFeatures();
+	             this.layerSegmentsKeep.null;
+	         }
+	         if (this.layerLengthKeep) {
+	             this.layerLengthKeep.destroyFeatures();
+	             this.layerLengthKeep.null;
+	         }
+	         if (this.layerAreaKeep) {
+	             this.layerAreaKeep.destroyFeatures();
+	             this.layerAreaKeep.null;
+	         }
         OpenLayers.Control.Measure.prototype.destroy.apply(this, arguments);
     },
 
@@ -490,7 +503,7 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
 
     /**
      * APIMethod: emptyKeeped
-     * Remove annotations from layers layerSegementsKeep, layerLengthKeep,
+     * Remove annotations from layers layerSegmentsKeep, layerLengthKeep,
      * layerAreaKeep.
      */
      emptyKeeped: function () {

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -498,6 +498,9 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
         if (this.layerAreaKeep) {
             this.layerAreaKeep.removeAllFeatures();
         }
+        this.layerSegmentsKeep = null;
+        this.layerLengthKeep = null;
+        this.layerAreaKeep = null;
     },
 
     /**

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -406,7 +406,8 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
             var _optionsStyles = this.styles || {},
                 _defaultStyles = OpenLayers.Control.DynamicMeasure.styles,
                 _self = this;
-            var _create = function(styleName, initialOptions, nameSuffix='') {
+            var _create = function(styleName, initialOptions, nameSuffix) {
+                nameSuffix = nameSuffix || '';
                 if (initialOptions === null) {
                     return null;
                 }

--- a/lib/OpenLayers/Control/DynamicMeasure.js
+++ b/lib/OpenLayers/Control/DynamicMeasure.js
@@ -499,9 +499,6 @@ OpenLayers.Control.DynamicMeasure = OpenLayers.Class(
         if (this.layerAreaKeep) {
             this.layerAreaKeep.removeAllFeatures();
         }
-        this.layerSegmentsKeep = null;
-        this.layerLengthKeep = null;
-        this.layerAreaKeep = null;
     },
 
     /**


### PR DESCRIPTION
## Summary

DynamicMeasure  allows us to store geometry of measured feature which is great!

In this pull request, we offer the possibility of storing annotations (segment, length and area) in  persistent layer which will stay available during the next measurements. The persistent annotations will even stay available after deactivation. They will be removed by calling a method on DynamicMeasure control.
## Implementation
### API modification
- `keep` : Property {Boolean} - keep annotations for every measures
- `emptyKeeped()` :  Method - empty keeped annotations;
- `layerSegmentsKeep`, `layerLengthKeep`, `layerAreaKeep` : Property  {`<OpenLayers.Layer.Vector>`} layers to keep copy of annotations;
### Code modifications

Several methods are affected by the proposed modification.

The method `copyAnnotations` makes most of the work.
